### PR TITLE
Added UIPilot - SwiftUI navigation library

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -625,6 +625,7 @@
   "https://github.com/brutella/xcollectiondata.git",
   "https://github.com/bryannorden/elo-rating-swift.git",
   "https://github.com/brycesteve/perfect-view2pdf.git",
+  "https://github.com/bteapot/Server.git",
   "https://github.com/btfranklin/Aesthete.git",
   "https://github.com/btfranklin/ControlledChaos.git",
   "https://github.com/btfranklin/Greebler.git",

--- a/packages.json
+++ b/packages.json
@@ -642,6 +642,7 @@
   "https://github.com/bwetherfield/pitchspeller.git",
   "https://github.com/cafielo/MNISTKit.git",
   "https://github.com/calda/CGPathIntersection.git",
+  "https://github.com/canopas/UIPilot.git",
   "https://github.com/calebkleveter/argon2.git",
   "https://github.com/capnslipp/NilCoalescingAssignmentOperators.git",
   "https://github.com/capnslipp/SCNMathExtensions.git",


### PR DESCRIPTION
The package(s) being submitted are:

* [UIPilot](https://github.com/canopas/UIPilot)

## Checklist

I have either:

* [x] Run `swift ./validate.swift`.

Or, checked that:

* [ ] The package repositories are publicly accessible.
* [ ] The packages all contain a `Package.swift` file in the root folder.
* [ ] The packages are written in Swift 5.0 or later.
* [ ] The packages all contain at least one product (either library or executable), and at least one product is usable in other Swift apps.
* [ ] The packages all have at least one release tagged as a [semantic version](https://semver.org/).
* [ ] The packages all output valid JSON from `swift package dump-package` with the latest Swift toolchain.
* [ ] The package URLs are all fully specified including the protocol (usually `https`) and the `.git` extension.
* [ ] The packages all compile without errors.
* [ ] The package list JSON file is sorted alphabetically.
